### PR TITLE
Make the air pump repair spacesuit parts

### DIFF
--- a/airpump.lua
+++ b/airpump.lua
@@ -47,6 +47,24 @@ local do_fill_bottle = function(inv)
 	return false
 end
 
+local do_repair_spacesuit = function(inv)
+	local part_names = {"spacesuit:helmet", "spacesuit:chestplate", "spacesuit:pants", "spacesuit:boots"}
+	for i = 1, inv:get_size("main") do
+		local stack = inv:get_stack("main", i)
+		if stack:get_wear() > 0 then
+			local stack_name = stack:get_name()
+			for _, part_name in ipairs(part_names) do
+				if stack_name == part_name then
+					stack:set_wear(0)
+					inv:set_stack("main", i, stack)
+					return true
+				end
+			end
+		end
+	end
+	return false
+end
+
 -- just enabled
 vacuum.airpump_enabled = function(meta)
 	return meta:get_int("enabled") == 1
@@ -220,6 +238,11 @@ minetest.register_abm({
 				used = do_empty_bottle(meta:get_inventory())
 			else
 				used = do_fill_bottle(meta:get_inventory())
+				-- The spacesuit mod must be loaded after this mod, so we can't check at the start.
+				local has_spacesuit = minetest.get_modpath("spacesuit")
+				if has_spacesuit then
+					used = used or do_repair_spacesuit(meta:get_inventory())
+				end
 			end
 
 			if used then


### PR DESCRIPTION
This makes the air pump able to repair one spacesuit part every five seconds. The part is repaired at once, rather than progressively (like the tool workshop). I think this makes sense: If five seconds are enough for the air pump to refill one air bottle, and one air bottle is enough to repair one spacesuit part by crafting, why wouldn't five seconds be enough for the air pump to repair the spacesuit part directly?