### PR TITLE
Get node drops from node def

### DIFF
--- a/physics.lua
+++ b/physics.lua
@@ -94,15 +94,6 @@ local drop_nodes = {
 	-- TODO: maybe: group:dig_immediate
 }
 
--- special drop cases
-local get_drop_name = function(name)
-	if name == "default:torch_wall" or name == "default:torch_ceiling" then
-		return "default:torch"
-	else
-		return name
-	end
-end
-
 -- weird nodes in vacuum
 minetest.register_abm({
         label = "space drop nodes",
@@ -119,9 +110,8 @@ minetest.register_abm({
 		local node = minetest.get_node(pos)
 		minetest.set_node(pos, {name = "vacuum:vacuum"})
 
-		local dropname = get_drop_name(node.name)
-		if dropname then
-			minetest.add_item(pos, {name = dropname})
+		for _, drop in pairs(minetest.get_node_drops(node.name)) do
+			minetest.add_item(pos, ItemStack(drop))
 		end
 	end)
 })


### PR DESCRIPTION
This modifies the ABM for nodes dropping in space to get node drops from the node def instead of using the node name.

For some nodes (all tree trunks), the ABM was executed multiple times, dropping vacuum. For jungle trees and empty rubber trees, the ABM was executed four times, which generated three vacuum items. In singleplayer, it's possible to drop other items (such as bedrock:deepstone) using Mesecons with a very small delay.